### PR TITLE
Added 'f0' suffix to floating point constants in unit tests

### DIFF
--- a/t/lang/compiler/compile-data.lisp
+++ b/t/lang/compiler/compile-data.lisp
@@ -49,8 +49,8 @@
 ;;;
 
 (subtest "COMPILE-FLOAT"
-  (is (compile-float 1.0) "1.0f")
-  (is (compile-float 1.23456789012345) "1.2345679f"))
+  (is (compile-float 1.0f0) "1.0f")
+  (is (compile-float 1.23456789012345f0) "1.2345679f"))
 
 
 ;;;

--- a/t/lang/compiler/compile-expression.lisp
+++ b/t/lang/compiler/compile-expression.lisp
@@ -75,7 +75,7 @@
   (is (compile-literal 1) "1"
       "basic case 3")
 
-  (is (compile-literal 1.0) "1.0f"
+  (is (compile-literal 1.0f0) "1.0f"
       "basic case 4")
 
   (is (compile-literal 1.0d0) "1.0"
@@ -162,7 +162,7 @@
         "mod integer")
     (is (compile-arithmetic '(+ 1 1 (- 1 1)) var-env func-env) "((1 + 1) + (1 - 1))"
         "mix integer")
-    (is (compile-arithmetic '(+ 1.0 2.0 3.0 4.0) var-env func-env)
+    (is (compile-arithmetic '(+ 1.0f0 2.0f0 3.0f0 4.0f0) var-env func-env)
         "(((1.0f + 2.0f) + 3.0f) + 4.0f)"
         "add float")))
 
@@ -185,7 +185,7 @@
         "basic case 2")
     (is (compile-function '(- 1) var-env func-env) "-(1)"
         "basic case 3")
-    (is (compile-function '(+ (float3 1.0 1.0 1.0) (float3 2.0 2.0 2.0))
+    (is (compile-function '(+ (float3 1.0f0 1.0f0 1.0f0) (float3 2.0f0 2.0f0 2.0f0))
                           var-env func-env)
         "((float3)(1.0f, 1.0f, 1.0f) + (float3)(2.0f, 2.0f, 2.0f))"
         "float3 constructor")

--- a/t/lang/compiler/compile-program.lisp
+++ b/t/lang/compiler/compile-program.lisp
@@ -23,7 +23,7 @@
 
   (let ((program (make-program)))
     (program-define-memory program 'a :constant 1)
-    (program-define-memory program 'b :global 1.0)
+    (program-define-memory program 'b :global 1.0f0)
     (program-define-function program 'foo 'void '((x int*))
                             '((set (aref x 0) (bar 1))
                               (return)))

--- a/t/lang/compiler/compile-statement.lisp
+++ b/t/lang/compiler/compile-statement.lisp
@@ -171,7 +171,7 @@
                      "basic case 4")
 
   (test-local-memory '(with-local-memory ((a float 16 16))
-                       (set (aref a 0 0) 1.0))
+                       (set (aref a 0 0) 1.0f0))
                      (unlines "{"
                               "  __local float a[16][16];"
                               "  a[0][0] = 1.0f;"
@@ -179,7 +179,7 @@
                      "basic case 5")
 
   (test-local-memory '(with-local-memory ((a float (+ 16 2)))
-                       (set (aref a 0) 1.0))
+                       (set (aref a 0) 1.0f0))
                      (unlines "{"
                               "  __local float a[(16 + 2)];"
                               "  a[0] = 1.0f;"
@@ -187,7 +187,7 @@
                      "store to local memory")
 
   (test-local-memory '(with-local-memory ((a float (+ 16 2)))
-                       (let ((b 0.0))
+                       (let ((b 0.0f0))
                          (set b (aref a 0))))
                      (unlines "{"
                               "  __local float a[(16 + 2)];"
@@ -206,7 +206,7 @@
 
   (multiple-value-bind (var-env func-env) (empty-environment)
     (let ((lisp-code '(with-local-memory ((a float 16 16))
-                       (set (aref a 0) 1.0))))
+                       (set (aref a 0) 1.0f0))))
       (is-error (compile-with-local-memory lisp-code var-env func-env)
                 simple-error))))
 
@@ -222,19 +222,19 @@
     (is (compile-set '(set x 1) var-env func-env)
         (unlines "x = 1;")
         "basic case 1")
-    (is-error (compile-set '(set x 1.0) var-env func-env) simple-error))
+    (is-error (compile-set '(set x 1.0f0) var-env func-env) simple-error))
 
   (multiple-value-bind (var-env func-env) (empty-environment)
     (setf var-env (variable-environment-add-variable 'x 'int* var-env))
     (is (compile-set '(set (aref x 0) 1) var-env func-env)
         (unlines "x[0] = 1;")
         "basic case 2")
-    (is-error (compile-set '(set (aref x 0) 1.0) var-env func-env)
+    (is-error (compile-set '(set (aref x 0) 1.0f0) var-env func-env)
               simple-error))
 
   (multiple-value-bind (var-env func-env) (empty-environment)
     (setf var-env (variable-environment-add-variable 'x 'float3 var-env))
-    (is (compile-set '(set (float3-x x) 1.0) var-env func-env)
+    (is (compile-set '(set (float3-x x) 1.0f0) var-env func-env)
         (unlines "x.x = 1.0f;")
         "basic case 3")
     (is-error (compile-set '(set (float3-x x) 1) var-env func-env)

--- a/t/lang/compiler/type-of-expression.lisp
+++ b/t/lang/compiler/type-of-expression.lisp
@@ -62,7 +62,7 @@
   (is (type-of-literal 1) 'int
       "basic case 3")
 
-  (is (type-of-literal 1.0) 'float
+  (is (type-of-literal 1.0f0) 'float
       "basic case 4")
 
   (is (type-of-literal 1.0d0) 'double
@@ -164,14 +164,14 @@
                                                      (empty-function-environment))))
     (is (type-of-function '(+ 1 1) var-env func-env) 'int)
     (is (type-of-function '(foo 1 1) var-env func-env) 'int)
-    (is (type-of-function '(+ 1.0 1.0) var-env func-env) 'float)
-    (is-error (type-of-function '(+ 1 1.0) var-env func-env) simple-error)
-    (is (type-of-function '(pow 1.0 1.0) var-env func-env) 'float)
-    (is (type-of-function '(half-cos 1.0) var-env func-env) 'float)
+    (is (type-of-function '(+ 1.0f0 1.0f0) var-env func-env) 'float)
+    (is-error (type-of-function '(+ 1 1.0f0) var-env func-env) simple-error)
+    (is (type-of-function '(pow 1.0f0 1.0f0) var-env func-env) 'float)
+    (is (type-of-function '(half-cos 1.0f0) var-env func-env) 'float)
     (is-error (type-of-function '(half-divide 1.0) var-env func-env) simple-error)
-    (is (type-of-function '(native-cos 1.0) var-env func-env) 'float)
+    (is (type-of-function '(native-cos 1.0f0) var-env func-env) 'float)
     (is-error (type-of-function '(native-divide 1.0) var-env func-env) simple-error)
     (is (type-of-function '(popcount 1) var-env func-env) 'int)
-    (is (type-of-function '(degrees 1.0) var-env func-env) 'float)))
+    (is (type-of-function '(degrees 1.0f0) var-env func-env) 'float)))
 
 (finalize)

--- a/t/lang/data.lisp
+++ b/t/lang/data.lisp
@@ -22,8 +22,8 @@
 
 (let ((cffi-type (cffi-type 'float3)))
   (cffi:with-foreign-object (x cffi-type)
-  (setf (cffi:mem-ref x cffi-type) (make-float3 1.0 1.0 1.0))
-  (is (cffi:mem-ref x cffi-type) (make-float3 1.0 1.0 1.0)
+  (setf (cffi:mem-ref x cffi-type) (make-float3 1.0f0 1.0f0 1.0f0))
+  (is (cffi:mem-ref x cffi-type) (make-float3 1.0f0 1.0f0 1.0f0)
       :test #'float3-=
       "basic case 1")))
 


### PR DESCRIPTION
Explicitly use single-floats in the unit tests so they pass when *read-default-float-format* is set to 'double-float or 'long-float .